### PR TITLE
Fix postgis package version in order to build master for PG 10.5 and Postgis 2.5

### DIFF
--- a/10-2.5/Dockerfile
+++ b/10-2.5/Dockerfile
@@ -2,7 +2,7 @@ FROM postgres:10
 MAINTAINER Mike Dillon <mike@appropriate.io>
 
 ENV POSTGIS_MAJOR 2.5
-ENV POSTGIS_VERSION 2.5.0+dfsg-1.pgdg90+1
+ENV POSTGIS_VERSION 2.5.0+dfsg-2.pgdg90+1
 
 RUN apt-get update \
       && apt-cache showpkg postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR \


### PR DESCRIPTION
Applying the fix suggested in https://github.com/appropriate/docker-postgis/issues/111 to use `2.5.0+dfsg-2.pgdg90+1` instead of `2.5.0+dfsg-1.pgdg90+1`

Basically, the `-1` version is not available in the postgis packages, but the `-2` version is: https://apt.postgresql.org/pub/repos/apt/pool/main/p/postgis/

I verified that I could build this locally.
